### PR TITLE
Replace iframe audio with browser native <audio> element

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,11 +129,9 @@
         </div>
         <!-- End Mailchimp Signup-->
 
-        
-        <!-- Wikimedia Commons Musikplayer -->
-        <iframe src="https://commons.wikimedia.org/wiki/File:Strauss,_An_der_sch%C3%B6nen_blauen_Donau.ogg?embedplayer=yes" width="120" height="NaN" frameborder="0">
-        </iframe>
-        <!-- End Wikimedia Commons Musikplayer -->
+        <div style="text-align: center;">
+            <audio src="https://commons.wikimedia.org/wiki/File:Strauss,_An_der_sch%C3%B6nen_blauen_Donau.ogg" controls></audio>
+        </div>
 
         <footer>
             <p class="footer footer2" style="font-size: 12px; color: #ffffff;">©2018 Huber &amp; Partner</p>


### PR DESCRIPTION
Hey Raphael! I updated the audio to use the <audio> HTML tag and centered it.
This is what it looks like:

**Firefox**:
![silvester2018_ff](https://user-images.githubusercontent.com/15364860/48757948-b4605480-ec9e-11e8-91b8-db5e74e1dba0.png)

**Chrome**:
![silvester2018_chrome](https://user-images.githubusercontent.com/15364860/48757959-bb876280-ec9e-11e8-8d38-ad6e834e4fc8.png)
